### PR TITLE
leave software/winrm in server, and removed obsolete done from split.sh

### DIFF
--- a/library-whitelist.txt
+++ b/library-whitelist.txt
@@ -1,3 +1,10 @@
-software
+software/base
+software/database
+software/messaging
+software/monitoring
+software/network
+software/nosql
+software/osgi
+software/webapp
 examples
 sandbox

--- a/split.sh
+++ b/split.sh
@@ -67,5 +67,5 @@ new_repo brooklyn-dist
 cleanup brooklyn-dist
 
 new_repo brooklyn-server
-( cd new-repos/TEMP-brooklyn-server && git filter-branch --index-filter "git rm -q -r --cached --ignore-unmatch $( cat ../../{docs,library,ui,dist}-whitelist.txt | tr '\n' ' ' ); done" --tag-name-filter cat --prune-empty master ${branches} )
+( cd new-repos/TEMP-brooklyn-server && git filter-branch --index-filter "git rm -q -r --cached --ignore-unmatch $( cat ../../{docs,library,ui,dist}-whitelist.txt | tr '\n' ' ' )" --tag-name-filter cat --prune-empty master ${branches} )
 cleanup brooklyn-server


### PR DESCRIPTION
Leaving `software/winrm` in brooklyn-server as discussed on dev list (thread titled "Repository splitting script").

Fixed the brooklyn-server index-filter, it wasn't running in its current state on master.